### PR TITLE
fix: fields property not being parsed correctly

### DIFF
--- a/cli/src/casl/casl.service.ts
+++ b/cli/src/casl/casl.service.ts
@@ -124,7 +124,7 @@ export class CaslService {
             tableMetadata.table.name;
 
           const fields = !rolePermission?.permission?.columns?.length
-            ? null
+            ? ['']
             : rolePermission.permission.columns;
 
           const conditions =

--- a/cli/src/common/utils/capture-test-error.spec.ts
+++ b/cli/src/common/utils/capture-test-error.spec.ts
@@ -1,0 +1,27 @@
+import { UnknownError, captureTestError } from './capture-test-error';
+
+class CustomError {}
+
+describe('captureTestError', () => {
+  describe('when the function passed as argument does not throw or reject', () => {
+    it('should throw with UnknownError', async () => {
+      try {
+        await captureTestError(() => {
+          return true;
+        });
+      } catch (error) {
+        expect(error).toBeInstanceOf(UnknownError);
+      }
+    });
+  });
+
+  describe('otherwise it should return the rejected or throwed error', () => {
+    it('should throw with UnknownError', async () => {
+      const error = await captureTestError(async () => {
+        await Promise.reject(new CustomError());
+      });
+
+      expect(error).toBeInstanceOf(CustomError);
+    });
+  });
+});

--- a/cli/src/common/utils/capture-test-error.ts
+++ b/cli/src/common/utils/capture-test-error.ts
@@ -1,0 +1,16 @@
+export class UnknownError extends Error {}
+
+/**
+ * Capture the error and return it to be used in jest assertions.
+ *
+ * @see https://github.com/jest-community/eslint-plugin-jest/blob/v27.2.3/docs/rules/no-conditional-expect.md
+ */
+export async function captureTestError<T>(func: () => unknown): Promise<T> {
+  try {
+    await func();
+
+    throw new UnknownError();
+  } catch (error) {
+    return error as T;
+  }
+}

--- a/cli/test/app.e2e-spec.ts
+++ b/cli/test/app.e2e-spec.ts
@@ -66,6 +66,54 @@ describe('CaslGeneratorCommand (e2e)', () => {
   });
 
   describe('READ', () => {
+    describe('when the permission has no selected columns', () => {
+      test('"id" is equal to x-hasura-user-id selecting id column', async () => {
+        await hasuraRepository.createSelectPermission({
+          table: 'users',
+          role: 'user',
+          permission: {
+            columns: [],
+            filter: {
+              id: {
+                _eq: 'x-hasura-user-id',
+              },
+            },
+          },
+          headers: options,
+        });
+
+        await CommandTestFactory.run(commandModule, [
+          '-s',
+          options.hasuraAdminSecret,
+          '-he',
+          options.hasuraEndpointUrl,
+          '-f',
+          'true',
+        ]);
+
+        const permissionsJSON = await loadPermissions();
+
+        const appAbility = defineAbilityfor(
+          {
+            id: '1',
+            user_roles: [{ role: 'ADMIN', user_id: '1' }],
+          },
+          permissionsJSON,
+        );
+
+        const test = appAbility.can(
+          'READ',
+          {
+            __customSubject: Subjects.User,
+            id: '1',
+          },
+          'id',
+        );
+
+        expect(test).toBe(false);
+      });
+    });
+
     describe('when _exists operator is used', () => {
       test('exists table "user_roles" where "role" equals to "ADMIN"', async () => {
         await hasuraRepository.createSelectPermission({
@@ -1118,6 +1166,54 @@ describe('CaslGeneratorCommand (e2e)', () => {
   });
 
   describe('INSERT', () => {
+    describe('when the permission has no selected columns', () => {
+      test('"id" is equal to x-hasura-user-id inserting with id column', async () => {
+        await hasuraRepository.createInsertPermission({
+          table: 'users',
+          role: 'user',
+          permission: {
+            columns: [],
+            check: {
+              id: {
+                _eq: 'x-hasura-user-id',
+              },
+            },
+          },
+          headers: options,
+        });
+
+        await CommandTestFactory.run(commandModule, [
+          '-s',
+          options.hasuraAdminSecret,
+          '-he',
+          options.hasuraEndpointUrl,
+          '-f',
+          'true',
+        ]);
+
+        const permissionsJSON = await loadPermissions();
+
+        const appAbility = defineAbilityfor(
+          {
+            id: '1',
+            user_roles: [{ role: 'ADMIN', user_id: '1' }],
+          },
+          permissionsJSON,
+        );
+
+        const test = appAbility.can(
+          'INSERT',
+          {
+            __customSubject: Subjects.User,
+            id: '1',
+          },
+          'id',
+        );
+
+        expect(test).toBe(false);
+      });
+    });
+
     describe('when _exists operator is used', () => {
       test('exists table "user_roles" where "role" equals to "ADMIN"', async () => {
         await hasuraRepository.createInsertPermission({
@@ -2170,6 +2266,54 @@ describe('CaslGeneratorCommand (e2e)', () => {
   });
 
   describe('UPDATE', () => {
+    describe('when the permission has no selected columns', () => {
+      test('"id" is equal to x-hasura-user-id updating id', async () => {
+        await hasuraRepository.createUpdatePermission({
+          table: 'users',
+          role: 'user',
+          permission: {
+            columns: [],
+            filter: {
+              id: {
+                _eq: 'x-hasura-user-id',
+              },
+            },
+          },
+          headers: options,
+        });
+
+        await CommandTestFactory.run(commandModule, [
+          '-s',
+          options.hasuraAdminSecret,
+          '-he',
+          options.hasuraEndpointUrl,
+          '-f',
+          'true',
+        ]);
+
+        const permissionsJSON = await loadPermissions();
+
+        const appAbility = defineAbilityfor(
+          {
+            id: '1',
+            user_roles: [{ role: 'ADMIN', user_id: '1' }],
+          },
+          permissionsJSON,
+        );
+
+        const test = appAbility.can(
+          'UPDATE',
+          {
+            __customSubject: Subjects.User,
+            id: '1',
+          },
+          'id',
+        );
+
+        expect(test).toBe(false);
+      });
+    });
+
     describe('when _exists operator is used', () => {
       test('exists table "user_roles" where "role" equals to "ADMIN"', async () => {
         await hasuraRepository.createUpdatePermission({


### PR DESCRIPTION
This PR adds the following:

- Fix the Casl's ability to give full control over the field inserts, reads, and updates when the Hasura permission has no selected columns.

Closes #16