### PR TITLE
fix: package marked as private

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,10 +1,10 @@
 {
   "name": "p-gen",
   "bin": "dist/main.js",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "A command line to transform Hasura permissions into Casl-compatible ones.",
   "author": "Juan Lunar",
-  "private": true,
+  "private": false,
   "license": "MIT",
   "scripts": {
     "build": "NODE_ENV=production nest build",


### PR DESCRIPTION
This PR adds the following:

- Change the package to public instead of private in the package.json.

Closes #22