### PR TITLE
fix: package name collision on the npm registry

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,6 +11,7 @@ jobs:
         with:
           node-version: '18.18'
           registry-url: 'https://registry.npmjs.org'
-      - run: cd cli && yarn publish:prod
+      - run: cd cli && yarn build:prod
+      - run: yarn publish --access=public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,8 @@
 {
-  "name": "p-gen",
-  "bin": "dist/main.js",
+  "name": "@lunarj/p-gen",
+  "bin": {
+    "p-gen": "dist/main.js"
+  },
   "version": "1.0.2",
   "description": "A command line to transform Hasura permissions into Casl-compatible ones.",
   "author": "Juan Lunar",
@@ -28,8 +30,7 @@
     "posttest:e2e:watch": "yarn test:e2e:down",
     "test:e2e:down": "docker compose kill hasura && docker compose down",
     "call": "NODE_ENV=development npx ts-node src/main.ts",
-    "fresh:install": "rm -r node_modules | echo && yarn install --frozen-lockfile",
-    "publish:prod": "yarn fresh:install && yarn build && yarn fresh:install --production && yarn publish"
+    "fresh:install": "rm -r node_modules | echo && yarn install --frozen-lockfile"
   },
   "dependencies": {
     "@nestjs/axios": "^3.0.2",


### PR DESCRIPTION
This PR adds the following:

- Change the package name to @lunarj/p-gen to avoid name collision on the NPM registry.

Closes #24