### PR TITLE
fix: the"publish" script being executed in the wrong directory

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,6 +12,6 @@ jobs:
           node-version: '18.18'
           registry-url: 'https://registry.npmjs.org'
       - run: cd cli && yarn build:prod
-      - run: yarn publish --access=public
+      - run: cd cli && yarn publish --access=public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR adds the following:

- Navigate to the "cli" directory before publishing the package.

Closes #26