### PR TITLE
chore: bump the CLI version to 1.0.8

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -3,7 +3,7 @@
   "bin": {
     "p-gen": "dist/main.js"
   },
-  "version": "1.0.6",
+  "version": "1.0.8",
   "description": "A command line to transform Hasura permissions into Casl-compatible ones.",
   "author": "Juan Lunar",
   "private": false,


### PR DESCRIPTION
This PR adds the following:

- Bump the CLI version to 1.0.8.