### PR TITLE
Feat/#34_add-filter-by-permission-type

### DIFF
--- a/cli/__mocks__/config-service.mock.ts
+++ b/cli/__mocks__/config-service.mock.ts
@@ -1,0 +1,10 @@
+import { Mock } from 'vitest';
+import { ConfigService } from '../src/cosmiconfig/config/config.service';
+
+export type ConfigServiceMock = Record<keyof ConfigService, Mock>;
+
+export function createConfigServiceMock(): ConfigServiceMock {
+  return {
+    getConfig: vi.fn(),
+  };
+}

--- a/cli/__mocks__/cosmiconfig-service.mock.ts
+++ b/cli/__mocks__/cosmiconfig-service.mock.ts
@@ -1,0 +1,12 @@
+import { CosmiconfigService } from '../src/cosmiconfig/cosmiconfig.service';
+import { Mock } from 'vitest';
+
+export type CosmiConfigServiceMock = Record<keyof CosmiconfigService, Mock>;
+
+export function createCosmiConfigServiceMock(): CosmiConfigServiceMock {
+  return {
+    load: vi.fn(),
+    loadOrCreate: vi.fn(),
+    searchWithoutCache: vi.fn(),
+  };
+}

--- a/cli/__mocks__/hasura-service.mock.ts
+++ b/cli/__mocks__/hasura-service.mock.ts
@@ -1,0 +1,10 @@
+import type { Mock } from 'vitest';
+import { HasuraService } from '../src/hasura/hasura.service';
+
+export type HasuraServiceMock = Record<keyof HasuraService, Mock>;
+
+export function createHasuraServiceMock(): HasuraServiceMock {
+  return {
+    filterTablesMetadata: vi.fn(),
+  };
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "NODE_ENV=production nest build",
-    "build:prod": "yarn fresh:install && NODE_ENV=production nest build && rm -r node_modules && yarn fresh:install --production",
+    "build:prod": "yarn fresh:install && NODE_ENV=production nest build && yarn fresh:install --production",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "NODE_ENV=development nest start",
     "start:dev": "NODE_ENV=development nest start --watch",

--- a/cli/src/casl/casl-generator-command.ts
+++ b/cli/src/casl/casl-generator-command.ts
@@ -31,6 +31,7 @@ export class CaslGeneratorCommand extends CommandRunner {
       dataSource = DEFAULT_DATA_SOURCE,
       flat = false,
     } = options;
+
     const permissions = await this.caslService.generateCaslPermissions({
       hasuraAdminSecret,
       hasuraEndpointUrl,

--- a/cli/src/casl/casl.service.spec.ts
+++ b/cli/src/casl/casl.service.spec.ts
@@ -6,9 +6,12 @@ import { UtilsService } from '../utils/utils.service';
 import { createUtilsServiceMock } from '__mocks__/utils-service.mock';
 import { LoggerService } from '../logger/logger.service';
 import { createLoggerServiceMock } from '__mocks__/logger-service.mock';
-import { CONFIG_OPTIONS_TOKEN } from '../cosmiconfig/constants/injection-tokens.constant';
 import { createCaslPermissionTransformerMock } from '__mocks__/casl-permission-transformer.mock';
 import { CaslPermissionTransformer } from './casl-permission-transformer/casl-permission-transformer';
+import { HasuraService } from '../hasura/hasura.service';
+import { createHasuraServiceMock } from '__mocks__/hasura-service.mock';
+import { ConfigService } from '../cosmiconfig/config/config.service';
+import { createConfigServiceMock } from '__mocks__/config-service.mock';
 
 describe('CaslService', () => {
   let service: CaslService;
@@ -29,12 +32,16 @@ describe('CaslService', () => {
           useValue: createLoggerServiceMock(),
         },
         {
-          provide: CONFIG_OPTIONS_TOKEN,
-          useValue: {},
+          provide: ConfigService,
+          useValue: createConfigServiceMock,
         },
         {
           provide: CaslPermissionTransformer,
           useValue: createCaslPermissionTransformerMock(),
+        },
+        {
+          provide: HasuraService,
+          useValue: createHasuraServiceMock(),
         },
         CaslService,
       ],

--- a/cli/src/common/types/index.ts
+++ b/cli/src/common/types/index.ts
@@ -1,9 +1,12 @@
+import { type HasuraPermissionType } from '../../hasura/constants/permissions.constant';
+
 export type Config = {
   transformers?: {
     action: (value: string) => string;
     subject: (value: string) => string;
   };
   replacements?: Record<string, string>;
+  include?: Record<string, HasuraPermissionType[]>;
   exports?: ConfigExports;
 };
 

--- a/cli/src/cosmiconfig/config/config.service.spec.ts
+++ b/cli/src/cosmiconfig/config/config.service.spec.ts
@@ -1,0 +1,37 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from './config.service';
+import { CONFIG_OPTIONS_TOKEN } from '../constants/injection-tokens.constant';
+
+describe('ConfigService', () => {
+  let service: ConfigService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        {
+          provide: CONFIG_OPTIONS_TOKEN,
+          useValue: {
+            test: 'option',
+          },
+        },
+        ConfigService,
+      ],
+    }).compile();
+
+    service = module.get<ConfigService>(ConfigService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getConfig', () => {
+    it('should return the config object', () => {
+      const result = service.getConfig();
+
+      expect(result).toStrictEqual({
+        test: 'option',
+      });
+    });
+  });
+});

--- a/cli/src/cosmiconfig/config/config.service.ts
+++ b/cli/src/cosmiconfig/config/config.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { InjectConfigOptions } from '../decorators/inject-config-options.decorator';
+import type { Config } from '../../common/types';
+
+@Injectable()
+export class ConfigService {
+  constructor(@InjectConfigOptions() private readonly configOptions: Config) {}
+
+  getConfig(): Config {
+    return this.configOptions;
+  }
+}

--- a/cli/src/cosmiconfig/cosmiconfig.module.ts
+++ b/cli/src/cosmiconfig/cosmiconfig.module.ts
@@ -2,6 +2,7 @@ import { Global, Module } from '@nestjs/common';
 import { CosmiconfigService } from './cosmiconfig.service';
 import { CaslGeneratorCommand } from '../casl/casl-generator-command';
 import { CONFIG_OPTIONS_TOKEN } from './constants/injection-tokens.constant';
+import { ConfigService } from './config/config.service';
 
 @Global()
 @Module({
@@ -18,7 +19,8 @@ import { CONFIG_OPTIONS_TOKEN } from './constants/injection-tokens.constant';
         return config;
       },
     },
+    ConfigService,
   ],
-  exports: [CosmiconfigService, CONFIG_OPTIONS_TOKEN],
+  exports: [CosmiconfigService, CONFIG_OPTIONS_TOKEN, ConfigService],
 })
 export class CosmiconfigModule {}

--- a/cli/src/hasura/constants/permissions.constant.ts
+++ b/cli/src/hasura/constants/permissions.constant.ts
@@ -4,3 +4,5 @@ export const hasuraPermissionTypes = [
   'update_permissions',
   'delete_permissions',
 ] as const;
+
+export type HasuraPermissionType = (typeof hasuraPermissionTypes)[number];

--- a/cli/src/hasura/hasura.module.ts
+++ b/cli/src/hasura/hasura.module.ts
@@ -2,6 +2,7 @@ import { HttpModule } from '@nestjs/axios';
 import { Module } from '@nestjs/common';
 import { HasuraRepository } from './hasura.repository';
 import { IHasuraRepository } from './ihasura-repository.interface';
+import { HasuraService } from './hasura.service';
 
 @Module({
   imports: [HttpModule],
@@ -10,7 +11,8 @@ import { IHasuraRepository } from './ihasura-repository.interface';
       provide: IHasuraRepository,
       useClass: HasuraRepository,
     },
+    HasuraService,
   ],
-  exports: [IHasuraRepository],
+  exports: [IHasuraRepository, HasuraService],
 })
 export class HasuraModule {}

--- a/cli/src/hasura/hasura.repository.ts
+++ b/cli/src/hasura/hasura.repository.ts
@@ -56,19 +56,9 @@ export class HasuraRepository implements IHasuraRepository {
     } catch (err) {
       const error = err as AxiosError<{ error?: string }>;
 
-      if (error.code === 'ECONNREFUSED') {
-        throw new HasuraConnectionError(hasuraEndpointUrl);
-      }
+      const errorToThrow = this.resolveErrorThrown(error, hasuraEndpointUrl);
 
-      if (error.response?.status === 401) {
-        throw new UnauthorizedError();
-      }
-
-      if (error.response?.status === 404) {
-        throw new NotFoundError();
-      }
-
-      throw new Error(error.response?.data?.error ?? 'Unknown error.');
+      throw errorToThrow;
     }
   }
 
@@ -113,19 +103,9 @@ export class HasuraRepository implements IHasuraRepository {
     } catch (err) {
       const error = err as AxiosError<{ error?: string }>;
 
-      if (error.code === 'ECONNREFUSED') {
-        throw new HasuraConnectionError(hasuraEndpointUrl);
-      }
+      const errorToThrow = this.resolveErrorThrown(error, hasuraEndpointUrl);
 
-      if (error.response?.status === 401) {
-        throw new UnauthorizedError();
-      }
-
-      if (error.response?.status === 404) {
-        throw new NotFoundError();
-      }
-
-      throw new Error(error.response?.data?.error ?? 'Unknown error.');
+      throw errorToThrow;
     }
   }
 
@@ -170,19 +150,9 @@ export class HasuraRepository implements IHasuraRepository {
     } catch (err) {
       const error = err as AxiosError<{ error?: string }>;
 
-      if (error.code === 'ECONNREFUSED') {
-        throw new HasuraConnectionError(hasuraEndpointUrl);
-      }
+      const errorToThrow = this.resolveErrorThrown(error, hasuraEndpointUrl);
 
-      if (error.response?.status === 401) {
-        throw new UnauthorizedError();
-      }
-
-      if (error.response?.status === 404) {
-        throw new NotFoundError();
-      }
-
-      throw new Error(error.response?.data?.error ?? 'Unknown error.');
+      throw errorToThrow;
     }
   }
 
@@ -227,19 +197,9 @@ export class HasuraRepository implements IHasuraRepository {
     } catch (err) {
       const error = err as AxiosError<{ error?: string }>;
 
-      if (error.code === 'ECONNREFUSED') {
-        throw new HasuraConnectionError(hasuraEndpointUrl);
-      }
+      const errorToThrow = this.resolveErrorThrown(error, hasuraEndpointUrl);
 
-      if (error.response?.status === 401) {
-        throw new UnauthorizedError();
-      }
-
-      if (error.response?.status === 404) {
-        throw new NotFoundError();
-      }
-
-      throw new Error(error.response?.data?.error ?? 'Unknown error.');
+      throw errorToThrow;
     }
   }
 
@@ -284,19 +244,9 @@ export class HasuraRepository implements IHasuraRepository {
     } catch (err) {
       const error = err as AxiosError<{ error?: string }>;
 
-      if (error.code === 'ECONNREFUSED') {
-        throw new HasuraConnectionError(hasuraEndpointUrl);
-      }
+      const errorToThrow = this.resolveErrorThrown(error, hasuraEndpointUrl);
 
-      if (error.response?.status === 401) {
-        throw new UnauthorizedError();
-      }
-
-      if (error.response?.status === 404) {
-        throw new NotFoundError();
-      }
-
-      throw new Error(error.response?.data?.error ?? 'Unknown error.');
+      throw errorToThrow;
     }
   }
 
@@ -329,17 +279,7 @@ export class HasuraRepository implements IHasuraRepository {
         },
       );
 
-      // Retry 3 times in case the Hasura container is swill booting up.
-      const result = await firstValueFrom(
-        request,
-        // request.pipe(
-        //   map((value) => value),
-        //   retry({
-        //     count: 5,
-        //     delay: 500,
-        //   }),
-        // ),
-      );
+      const result = await firstValueFrom(request);
 
       return result.data;
     } catch (err) {
@@ -357,5 +297,28 @@ export class HasuraRepository implements IHasuraRepository {
 
       throw new Error(error.response?.data?.error ?? 'Unknown error.');
     }
+  }
+
+  /**
+   * Resolve Hasura fetch error.
+   *
+   */
+  private resolveErrorThrown(
+    err: AxiosError<{ error?: string }>,
+    hasuraEndpointUrl: string,
+  ) {
+    if (err.code === 'ECONNREFUSED' || err.code === 'ECONNRESET') {
+      return new HasuraConnectionError(hasuraEndpointUrl);
+    }
+
+    if (err.response?.status === 401) {
+      return new UnauthorizedError();
+    }
+
+    if (err.response?.status === 404) {
+      return new NotFoundError();
+    }
+
+    return new Error(err.response?.data?.error ?? 'Unknown error.');
   }
 }

--- a/cli/src/hasura/hasura.service.spec.ts
+++ b/cli/src/hasura/hasura.service.spec.ts
@@ -1,0 +1,128 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HasuraService } from './hasura.service';
+import type { HasuraMetadataTable } from './types';
+
+const mock = [
+  {
+    table: {
+      name: 'roles',
+      schema: 'public',
+    },
+    is_enum: true,
+    select_permissions: [
+      {
+        role: 'user',
+        permission: {
+          columns: [],
+          filter: {},
+        },
+        comment: '',
+      },
+    ],
+    insert_permissions: [
+      {
+        role: 'user',
+        permission: {
+          check: {
+            id: {
+              _eq: 'X-Hasura-User-Id',
+            },
+          },
+          columns: [],
+        },
+        comment: '',
+      },
+    ],
+  },
+  {
+    table: {
+      name: 'user_roles',
+      schema: 'public',
+    },
+  },
+  {
+    table: {
+      name: 'users',
+      schema: 'public',
+    },
+    array_relationships: [
+      {
+        name: 'user_roles',
+        using: {
+          foreign_key_constraint_on: {
+            column: 'user_id',
+            table: {
+              name: 'user_roles',
+              schema: 'public',
+            },
+          },
+        },
+      },
+    ],
+  },
+] as HasuraMetadataTable[];
+
+describe('HasuraService', () => {
+  let service: HasuraService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [HasuraService],
+    }).compile();
+
+    service = module.get<HasuraService>(HasuraService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('filterTablesMetadata', () => {
+    describe('when there is no property set in the include argument', () => {
+      it('should return the same tables received as argument', () => {
+        const result = service.filterTablesMetadata({}, mock);
+
+        expect(result).toStrictEqual(mock);
+      });
+    });
+
+    describe('otherwise', () => {
+      describe('when the table exists in the include object but it is an empty array', () => {
+        it('should return the entire table metadata', () => {
+          const permissionsMock = [...mock];
+
+          const result = service.filterTablesMetadata(
+            {
+              roles: [],
+            },
+            permissionsMock,
+          );
+
+          const roleTableMock = mock[0];
+
+          expect(result).toStrictEqual([roleTableMock]);
+        });
+      });
+
+      describe('otherwise', () => {
+        it('should return only the specified permissions in the include argument', () => {
+          const result = service.filterTablesMetadata(
+            {
+              roles: ['select_permissions'],
+            },
+            mock,
+          );
+
+          const permissionsMock = mock[0];
+
+          expect(result).toStrictEqual([
+            {
+              table: permissionsMock.table,
+              select_permissions: permissionsMock.select_permissions,
+            },
+          ]);
+        });
+      });
+    });
+  });
+});

--- a/cli/src/hasura/hasura.service.ts
+++ b/cli/src/hasura/hasura.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@nestjs/common';
+import type { HasuraMetadataTable } from './types';
+import { type HasuraPermissionType } from './constants/permissions.constant';
+
+@Injectable()
+export class HasuraService {
+  /**
+   * Filter permissions.
+   *
+   */
+  filterTablesMetadata(
+    include: Record<string, HasuraPermissionType[]>,
+    metadataTables: HasuraMetadataTable[],
+  ): HasuraMetadataTable[] {
+    const tablesToFilter = Object.keys(include);
+
+    if (!tablesToFilter?.length) {
+      return metadataTables;
+    }
+
+    const filteredTables: HasuraMetadataTable[] = [];
+
+    metadataTables.forEach((metadataTable) => {
+      const permissions = include[metadataTable.table.name];
+
+      if (!permissions) {
+        return;
+      }
+
+      if (!permissions.length) {
+        filteredTables.push(metadataTable);
+
+        return;
+      }
+
+      const metadataToInclude: HasuraMetadataTable = {
+        table: metadataTable.table,
+      };
+
+      permissions.forEach((permission) => {
+        metadataToInclude[permission] = metadataTable[permission];
+      });
+
+      filteredTables.push(metadataToInclude);
+    });
+
+    return filteredTables;
+  }
+}

--- a/cli/test/utils/config-options.ts
+++ b/cli/test/utils/config-options.ts
@@ -1,6 +1,7 @@
-import type { Config } from 'p-gen';
+import type { Config } from '../../src/common/types';
+import pluralize from 'pluralize';
 
-const config: Config = {
+export const configOptions: Config = {
   transformers: {
     action: (act: string) => {
       // Do your transformation.
@@ -20,7 +21,7 @@ const config: Config = {
     },
     subject: (sub: string) => {
       // Do your transformation.
-      return sub;
+      return pluralize.singular(sub).toUpperCase();
     },
   },
   replacements: {
@@ -29,7 +30,5 @@ const config: Config = {
   },
   include: {
     // users: ['insert_permissions'],
-  }
+  },
 };
-
-export default config;

--- a/cli/test/utils/wait-for.util.ts
+++ b/cli/test/utils/wait-for.util.ts
@@ -1,0 +1,31 @@
+/**
+ * Wait until the callback resolves a value.
+ *
+ */
+export async function waitFor(
+  cb: () => Promise<void>,
+  options = {} as WaitForOptions,
+) {
+  const { delay = 250 } = options;
+
+  try {
+    await cb();
+
+    return;
+  } catch (error) {
+    // Do nothing
+  }
+
+  const timeout = setTimeout(async () => {
+    await waitFor(cb, options);
+
+    clearTimeout(timeout);
+  }, delay);
+}
+
+export type WaitForOptions = {
+  /**
+   * Milliseconds.
+   */
+  delay?: number;
+};

--- a/hasura/Dockerfile
+++ b/hasura/Dockerfile
@@ -1,4 +1,4 @@
 FROM hasura/graphql-engine:v2.35.0.cli-migrations-v3
 
-COPY ./metadata[s] /hasura-metadata
-COPY /migration[s] /hasura-migrations
+COPY ./metadat[a] /hasura-metadata
+COPY ./migration[s] /hasura-migrations

--- a/hasura/metadata/databases/default/tables/public_roles.yaml
+++ b/hasura/metadata/databases/default/tables/public_roles.yaml
@@ -2,6 +2,14 @@ table:
   name: roles
   schema: public
 is_enum: true
+array_relationships:
+  - name: user_roles
+    using:
+      foreign_key_constraint_on:
+        column: role
+        table:
+          name: user_roles
+          schema: public
 select_permissions:
   - role: user
     permission:

--- a/hasura/metadata/databases/default/tables/public_user_roles.yaml
+++ b/hasura/metadata/databases/default/tables/public_user_roles.yaml
@@ -1,3 +1,10 @@
 table:
   name: user_roles
   schema: public
+object_relationships:
+  - name: roleByRole
+    using:
+      foreign_key_constraint_on: role
+  - name: user
+    using:
+      foreign_key_constraint_on: user_id


### PR DESCRIPTION
This PR adds the following:

- Add a new property to the p-gen.config.ts file to filter by table and permission type.
- Fix e2e tests failing due to the Hasura server not running yet.
- Improve the Hasura repository error handlers.
- Fix the Hasura Dockerfile causing the e2e tests to fail.

Closes #34