### PR TITLE
feat/#38_add-custom-export-location

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -37,6 +37,8 @@ yarn add @lunarj/p-gen -D
 
 `-f, --flat` generates permissions without the Hasura roles mapping. It will be a plain array with the permissions without the role separation.
 
+`-jp, --json-path` indicates the custom location to export the permissions JSON file.
+
 `-h, --help` prints the help on the terminal
 
 ## Understanding the config

--- a/cli/__mocks__/utils-service.mock.ts
+++ b/cli/__mocks__/utils-service.mock.ts
@@ -9,5 +9,6 @@ export function createUtilsServiceMock(): UtilsServiceMock {
     createConfigFile: vi.fn(),
     writeFile: vi.fn(),
     flatPermissionsMapping: vi.fn(),
+    fileOrDirExists: vi.fn(),
   };
 }

--- a/cli/src/casl/casl-generator-command.ts
+++ b/cli/src/casl/casl-generator-command.ts
@@ -29,6 +29,7 @@ export class CaslGeneratorCommand extends CommandRunner {
       hasuraAdminSecret,
       hasuraEndpointUrl = DEFAULT_HASURA_ENDPOINT_URL,
       dataSource = DEFAULT_DATA_SOURCE,
+      jsonPath,
       flat = false,
     } = options;
 
@@ -42,7 +43,9 @@ export class CaslGeneratorCommand extends CommandRunner {
       ? permissions
       : this.utilsService.flatPermissionsMapping(permissions);
 
-    await this.caslService.exportToJSON(resolvedPermissions);
+    await this.caslService.exportToJSON(resolvedPermissions, {
+      path: jsonPath,
+    });
   }
 
   @Option({
@@ -78,5 +81,13 @@ export class CaslGeneratorCommand extends CommandRunner {
   })
   parseFlat(value: string) {
     return value.toLowerCase() === 'true';
+  }
+
+  @Option({
+    flags: '-jp, --json-path [json-path]',
+    description: `Generates the permissions in the specified path. (default: current working directory)`,
+  })
+  parseJsonPath(value: string) {
+    return value;
   }
 }

--- a/cli/src/casl/casl.service.ts
+++ b/cli/src/casl/casl.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { IHasuraRepository } from '../hasura/ihasura-repository.interface';
 import type {
   CaslPermission,
+  ExportToJSONOptions,
   GenerateCaslPermissionsDto,
   PermissionsMappingByRole,
 } from './types';
@@ -65,8 +66,11 @@ export class CaslService {
    */
   async exportToJSON(
     permissionsMapping: PermissionsMappingByRole | CaslPermission[],
+    options = {} as ExportToJSONOptions,
   ) {
-    const permissionsFilePath = join(process.cwd(), 'permissions.json');
+    const { path = process.cwd() } = options;
+
+    const permissionsFilePath = join(path, 'permissions.json');
 
     const permissionsData = JSON.stringify(permissionsMapping, null, ' ');
 

--- a/cli/src/casl/types.ts
+++ b/cli/src/casl/types.ts
@@ -3,6 +3,7 @@ export type CaslGeneratorOptions = {
   dataSource?: string;
   hasuraEndpointUrl?: string;
   flat?: boolean;
+  jsonPath?: string;
 };
 
 export type GenerateCaslPermissionsDto = {
@@ -29,3 +30,7 @@ export interface DBSyncPermission
   fields: string | null;
   conditions: string;
 }
+
+export type ExportToJSONOptions = {
+  path?: string;
+};

--- a/cli/src/utils/utils.service.spec.ts
+++ b/cli/src/utils/utils.service.spec.ts
@@ -1,5 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UtilsService } from './utils.service';
+import { writeFile, mkdir, rm, access } from 'fs/promises';
+import { Mock } from 'vitest';
+import { captureTestError } from '../common/utils/capture-test-error';
+import { dirname } from 'path';
+
+vi.mock('fs/promises');
+vi.mock('path');
 
 describe('UtilsService', () => {
   let service: UtilsService;
@@ -20,6 +27,102 @@ describe('UtilsService', () => {
     describe('when the object has nested keys', () => {
       describe('when the first key starts with $', () => {
         it.todo('should return the first key with its value');
+      });
+    });
+  });
+
+  describe('writeFile', () => {
+    describe('when the something wrong happens trying to write the dir or the file', () => {
+      describe('when the directory exists before writing the file', () => {
+        it('should remove the file if it was already written', async () => {
+          (access as Mock).mockRejectedValue(undefined);
+
+          (mkdir as Mock).mockRejectedValue(new Error('test-error'));
+
+          const dirName = 'dir';
+
+          (dirname as Mock).mockReturnValue(dirName);
+
+          const error = await captureTestError<Error>(async () => {
+            await service.writeFile(`${dirName}/file.txt`, 'buffer');
+          });
+
+          expect(error).toBeInstanceOf(Error);
+
+          expect(error.message).toBe('test-error');
+
+          expect(rm).toHaveBeenCalledWith(dirName, {
+            recursive: true,
+            force: true,
+          });
+        });
+      });
+
+      describe('otherwise', () => {
+        it('should remove the entire directory', async () => {
+          (access as Mock).mockResolvedValue(undefined);
+
+          (mkdir as Mock).mockRejectedValue(new Error('test-error'));
+
+          const dirName = 'dir';
+
+          (dirname as Mock).mockReturnValue(dirName);
+
+          const filePath = `${dirName}/file.txt`;
+
+          const error = await captureTestError<Error>(async () => {
+            await service.writeFile(filePath, 'buffer');
+          });
+
+          expect(error).toBeInstanceOf(Error);
+
+          expect(error.message).toBe('test-error');
+
+          expect(rm).toHaveBeenCalledWith(filePath, {
+            recursive: true,
+            force: true,
+          });
+        });
+      });
+    });
+
+    describe('otherwise', () => {
+      it('should resolve with undefined', async () => {
+        (access as Mock).mockResolvedValue(undefined);
+
+        (mkdir as Mock).mockResolvedValue(undefined);
+
+        (writeFile as Mock).mockResolvedValue(undefined);
+
+        const dirName = 'dir';
+
+        const filePath = `${dirName}/file.txt`;
+
+        const result = await service.writeFile(filePath, 'buffer');
+
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('fileOrDirExists', () => {
+    describe('when the access module throws', () => {
+      it('should return false', async () => {
+        (access as Mock).mockRejectedValue(undefined);
+
+        const result = await service.fileOrDirExists('path');
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('otherwise', () => {
+      it('should return true', async () => {
+        (access as Mock).mockResolvedValue(true);
+
+        const result = await service.fileOrDirExists('path');
+
+        expect(result).toBe(true);
       });
     });
   });


### PR DESCRIPTION
This PR adds the following: 

- Add the --json-path option documentation.
- Add an option to export the permissions JSON file in a custom location.

Closes #38