### PR TITLE
fix: typescript declaration files missing from the build

### DIFF
--- a/cli/nest-cli.json
+++ b/cli/nest-cli.json
@@ -4,10 +4,6 @@
   "sourceRoot": "src",
   "compilerOptions": {
     "deleteOutDir": true,
-    "builder": {
-      "type": "swc",
-      "type-check": true
-    },
-    "assets": ["**/*.stub"]
+    "assets": ["**/*.stub", "**.d.ts"]
   }
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -3,7 +3,7 @@
   "bin": {
     "p-gen": "dist/main.js"
   },
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "A command line to transform Hasura permissions into Casl-compatible ones.",
   "author": "Juan Lunar",
   "private": false,

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -30,5 +30,5 @@
   "ts-node": {
     "swc": true
   },
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["dist"]
 }


### PR DESCRIPTION
This PR adds the following:

- Remove SWC as builder due missing ts declaration files.