### PR TITLE
fix: cosmiconfig module not being included in the build

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lunarj/p-gen",
   "bin": "dist/src/main.js",
-  "version": "1.2.12",
+  "version": "1.2.13",
   "description": "A command line to transform Hasura permissions into Casl-compatible ones.",
   "author": "Juan Lunar",
   "license": "MIT",
@@ -51,6 +51,7 @@
     "@nestjs/platform-express": "^10.0.0",
     "axios": "^1.6.8",
     "chalk": "4.1.2",
+    "cosmiconfig": "^9.0.0",
     "figlet": "^1.7.0",
     "flat": "^5.0.2",
     "lodash": "^4.17.21",

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -1150,6 +1150,7 @@ __metadata:
     "@vitest/coverage-v8": "npm:^1.4.0"
     axios: "npm:^1.6.8"
     chalk: "npm:4.1.2"
+    cosmiconfig: "npm:^9.0.0"
     eslint: "npm:^8.42.0"
     eslint-config-prettier: "npm:^9.0.0"
     eslint-plugin-prettier: "npm:^5.0.0"
@@ -3532,6 +3533,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cosmiconfig@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "cosmiconfig@npm:9.0.0"
+  dependencies:
+    env-paths: "npm:^2.2.1"
+    import-fresh: "npm:^3.3.0"
+    js-yaml: "npm:^4.1.0"
+    parse-json: "npm:^5.2.0"
+  peerDependencies:
+    typescript: ">=4.9.5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 10c0/1c1703be4f02a250b1d6ca3267e408ce16abfe8364193891afc94c2d5c060b69611fdc8d97af74b7e6d5d1aac0ab2fb94d6b079573146bc2d756c2484ce5f0ee
+  languageName: node
+  linkType: hard
+
 "create-jest@npm:^29.7.0":
   version: 29.7.0
   resolution: "create-jest@npm:29.7.0"
@@ -3829,7 +3847,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"env-paths@npm:^2.2.0":
+"env-paths@npm:^2.2.0, env-paths@npm:^2.2.1":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
   checksum: 10c0/285325677bf00e30845e330eec32894f5105529db97496ee3f598478e50f008c5352a41a30e5e72ec9de8a542b5a570b85699cd63bd2bc646dbcb9f311d83bc4


### PR DESCRIPTION
This PR adds the following:

- Fix TypeError: (0 , cosmiconfig_1.cosmiconfig) is not a function when using pnpm node-linker set to hoisted.

Fixes #56