### PR TITLE
fix(cli): replacement keys being replaced incorrectly

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lunarj/p-gen",
   "bin": "dist/src/main.js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A command line to transform Hasura permissions into Casl-compatible ones.",
   "author": "Juan Lunar",
   "license": "MIT",

--- a/cli/src/utils/utils.service.ts
+++ b/cli/src/utils/utils.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { readFile, writeFile, mkdir, rm, access } from 'fs/promises';
-import { join, dirname } from 'path';
-import { CONFIG_FILE_NAME } from '../common/constants';
+import type { PathLike } from 'fs';
+import { access, mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { dirname, join } from 'path';
 import type { Stream } from 'stream';
 import { CaslPermission, PermissionsMappingByRole } from '../casl/types';
-import type { PathLike } from 'fs';
+import { CONFIG_FILE_NAME } from '../common/constants';
 
 @Injectable()
 export class UtilsService {
@@ -17,7 +17,7 @@ export class UtilsService {
     const replacementKeys = Object.keys(replacements);
 
     replacementKeys.forEach((replacementKey) => {
-      const regex = new RegExp(replacementKey, 'ig');
+      const regex = new RegExp(`\\b${replacementKey}\\b`, 'ig');
 
       stringified = stringified.replaceAll(regex, () => {
         return replacements[replacementKey];


### PR DESCRIPTION
This PR adds the following:

- The replacements regex is now matching exact properties.

Fixes #60